### PR TITLE
feat: add daily automated repository heartbeat updates

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -1,0 +1,39 @@
+name: Daily Repository Update
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  daily-update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Update heartbeat file
+        run: python scripts/daily_update.py
+
+      - name: Commit and push if there are changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git add daily-heartbeat.md
+          git commit -m "chore: daily automated heartbeat update"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # extract_ner
+
+## Daily automatic GitHub update
+
+This repository now includes a GitHub Actions workflow that runs every day and updates `daily-heartbeat.md` automatically.
+
+- Workflow file: `.github/workflows/daily-update.yml`
+- Update script: `scripts/daily_update.py`
+- Output file: `daily-heartbeat.md`
+
+The workflow also supports manual runs from the **Actions** tab using `workflow_dispatch`.

--- a/daily-heartbeat.md
+++ b/daily-heartbeat.md
@@ -1,0 +1,5 @@
+# Daily Repository Heartbeat
+
+This file is updated automatically by GitHub Actions every day.
+
+Last automated update: 2026-03-05 18:48:11 UTC

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+STAMP_FILE = Path("daily-heartbeat.md")
+
+
+def write_heartbeat() -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    content = (
+        "# Daily Repository Heartbeat\n\n"
+        "This file is updated automatically by GitHub Actions every day.\n\n"
+        f"Last automated update: {now}\n"
+    )
+    STAMP_FILE.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    write_heartbeat()


### PR DESCRIPTION
### Motivation
- Ensure the repository receives a visible daily update even when no one is present by automating a small, safe change. 
- Allow manual runs from the Actions UI with `workflow_dispatch` for on-demand testing or re-runs. 
- Keep the automation minimal and auditable by writing a single `daily-heartbeat.md` file that records the UTC timestamp. 

### Description
- Add `.github/workflows/daily-update.yml` which is scheduled via `cron: "0 3 * * *"` and supports `workflow_dispatch`, and grants `contents: write` so the workflow can push changes. 
- Workflow checks out the repo, sets up Python, runs `scripts/daily_update.py`, and commits & pushes `daily-heartbeat.md` using the GitHub Actions bot account if there are changes. 
- Add `scripts/daily_update.py` which writes the current UTC timestamp into `daily-heartbeat.md`. 
- Add an initial `daily-heartbeat.md` and update `README.md` to document the workflow and script locations. 

### Testing
- Ran `python scripts/daily_update.py` locally and it executed successfully. 
- Verified `scripts/daily_update.py` compiles with `python -m py_compile scripts/daily_update.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9cfa9d3a08329b7c9683b00605dfc)