### PR TITLE
Use repository owner for commit author in daily-update workflow

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Commit and push if there are changes
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ github.repository_owner }}"
+          git config user.email "${{ github.event.repository.owner.id }}+${{ github.repository_owner }}@users.noreply.github.com"
 
           if git diff --quiet; then
             echo "No changes to commit."


### PR DESCRIPTION
### Motivation
- Replace the generic bot identity with the repository owner for commits from the daily update workflow so commit attribution reflects the repository owner rather than the generic `github-actions[bot]` account.

### Description
- In `.github/workflows/daily-update.yml` change the `git config` settings from the fixed bot values to use `git config user.name "${{ github.repository_owner }}"` and `git config user.email "${{ github.event.repository.owner.id }}+${{ github.repository_owner }}@users.noreply.github.com"` when committing automated heartbeat updates.

### Testing
- No automated tests were run for this workflow-only change; the update will be exercised when the GitHub Actions workflow runs on its next schedule or on manual dispatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d39ad62083299faa516c5a0f357b)